### PR TITLE
feat(metadata): add generic object view metadata endpoint

### DIFF
--- a/pythonik/specs/metadata.py
+++ b/pythonik/specs/metadata.py
@@ -6,9 +6,13 @@ from pythonik.models.mutation.metadata.mutate import (
     UpdateMetadataResponse,
 )
 from pythonik.specs.base import Spec
+from typing import Literal
 
 ASSET_METADATA_FROM_VIEW_PATH = "assets/{}/views/{}"
 UPDATE_ASSET_METADATA = "assets/{}/views/{}/"
+ASSET_OBJECT_VIEW_PATH = "v1/assets/{}/{}/{}/views/{}/"
+
+ObjectType = Literal["segments"]
 
 
 class MetadataSpec(Spec):
@@ -53,3 +57,18 @@ class MetadataSpec(Spec):
         )
 
         return self.parse_response(resp, UpdateMetadataResponse)
+
+    def put_object_view_metadata(
+        self, asset_id: str, object_type: ObjectType, object_id: str, view_id: str, metadata: UpdateMetadata
+    ) -> Response:
+        """Put metadata for a specific sub-object view of an asset"""
+        endpoint = ASSET_OBJECT_VIEW_PATH.format(asset_id, object_type, object_id, view_id)
+        resp = self._put(endpoint, json=metadata.model_dump())
+
+        return self.parse_response(resp, UpdateMetadataResponse)
+
+    def put_segment_view_metadata(
+        self, asset_id: str, segment_id: str, view_id: str, metadata: UpdateMetadata
+    ) -> Response:
+        """Put metadata for a segment of an asset"""
+        return self.put_object_view_metadata(asset_id, "segments", segment_id, view_id, metadata)

--- a/pythonik/tests/test_metadata.py
+++ b/pythonik/tests/test_metadata.py
@@ -18,6 +18,7 @@ from pythonik.specs.metadata import (
     ASSET_METADATA_FROM_VIEW_PATH,
     UPDATE_ASSET_METADATA,
     MetadataSpec,
+    ASSET_OBJECT_VIEW_PATH,
 )
 
 
@@ -159,3 +160,38 @@ def test_update_asset_metadata():
         m.put(mock_address, json=response_model.model_dump())
         client = PythonikClient(app_id=app_id, auth_token=auth_token, timeout=3)
         client.metadata().update_asset_metadata(asset_id, view_id, mutate_model)
+
+
+def test_put_segment_view_metadata():
+    with requests_mock.Mocker() as m:
+        app_id = str(uuid.uuid4())
+        auth_token = str(uuid.uuid4())
+        asset_id = str(uuid.uuid4())
+        segment_id = str(uuid.uuid4())
+        view_id = str(uuid.uuid4())
+        
+        # Create test payload
+        payload = {
+            "metadata_values": {
+                "field1": {
+                    "field_values": [{"value": "123"}]
+                }
+            }
+        }
+
+        mutate_model = UpdateMetadata.model_validate(payload)
+        response_model = UpdateMetadataResponse(
+            metadata_values=mutate_model.metadata_values.model_dump()
+        )
+
+        # Mock the endpoint using the ASSET_OBJECT_VIEW_PATH
+        mock_address = MetadataSpec.gen_url(
+            ASSET_OBJECT_VIEW_PATH.format(asset_id, "segments", segment_id, view_id)
+        )
+        m.put(mock_address, json=response_model.model_dump())
+
+        # Make the request
+        client = PythonikClient(app_id=app_id, auth_token=auth_token, timeout=3)
+        client.metadata().put_segment_view_metadata(
+            asset_id, segment_id, view_id, mutate_model
+        )


### PR DESCRIPTION
Add support for updating metadata on any object type via a new generic endpoint.
This includes:
- New PUT endpoint at /v1/assets/{asset_id}/{object_type}/{object_id}/views/{view_id}/
- New PUT segment view metadata endpoint
- Add comprehensive test coverage for the new functionality

This change improves code reusability and makes it easier to add support for
additional object types in the future.