### PR TITLE
refactor: rename and reorganize file set endpoints

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 2024-11-15 "filesets, more like files am i right? No? cool... cool... " - version 1.0.0
+
+### Changed
+- Renamed `GET_ASSETS_FILE_SET_PATH` to `GET_ASSETS_FILE_SETS_PATH` for better URL path consistency
+- Renamed `get_asset_file_sets()` method to `get_asset_file_set_files()` to better reflect its purpose
+- BACKWARDS INCOMPATIBLE CHANGE: `get_asset_file_sets()` is removed, use `get_asset_file_set_files()` instead
+- Simplified docstring for file set retrieval endpoint
+- Updated related test cases to match new method names
+
 ## 2024-11-14 "You want some, you lose some" - version 0.9.0
 
 ### Added

--- a/pythonik/specs/files.py
+++ b/pythonik/specs/files.py
@@ -1,5 +1,7 @@
 from urllib.parse import urlparse
 from xml.dom.minidom import parseString
+from functools import wraps
+import warnings
 
 import requests
 
@@ -440,6 +442,16 @@ class FilesSpec(Spec):
         return self.parse_response(response, File)
 
     def create_asset_filesets(
+        self, asset_id: str, body: FileSetCreate, exclude_defaults=True, **kwargs
+    ) -> Response:
+        warnings.warn(
+            "'create_asset_filesets' is deprecated. Use 'create_asset_file_sets' instead.",
+            DeprecationWarning,
+            stacklevel=2
+        )
+        return self.create_asset_file_sets(asset_id, body, exclude_defaults, **kwargs)
+
+    def create_asset_file_sets(
         self, asset_id: str, body: FileSetCreate, exclude_defaults=True, **kwargs
     ) -> Response:
         """

--- a/pythonik/specs/files.py
+++ b/pythonik/specs/files.py
@@ -38,7 +38,7 @@ GET_ASSETS_FORMATS_PATH = "assets/{}/formats/"
 GET_ASSETS_FORMAT_PATH = "assets/{}/formats/{}/"
 GET_ASSETS_FORMAT_COMPONENTS_PATH = "assets/{}/formats/{}/components"
 GET_ASSETS_FILES_PATH = "assets/{}/files/"
-GET_ASSETS_FILE_SET_PATH = "assets/{}/file_sets/"
+GET_ASSETS_FILE_SETS_PATH = "assets/{}/file_sets/"
 GET_ASSETS_FILE_SET_FILES_PATH = "assets/{}/file_sets/{}/files/"
 GET_STORAGE_PATH = "storages/{}/"
 GET_STORAGES_PATH = "storages/"
@@ -52,30 +52,6 @@ DELETE_ASSETS_FILE_PATH = "assets/{}/files/{}/"
 class FilesSpec(Spec):
     server = "API/files/"
 
-    def get_asset_file_sets(self, asset_id: str, file_sets_id: str, **kwargs) -> Response:
-        """
-        Retrieve file sets for a specific asset
-
-        Args:
-            asset_id: ID of the asset
-            file_sets_id: ID of the file set to retrieve
-            kwargs: additional kwargs passed to the request
-        
-        Returns:
-            Response(model=FileSetsFilesResponse)
-        
-        Required roles:
-            - can_read_files
-        
-        Raises:
-            - 401 Token is invalid
-            - 404 FileSets for this asset don't exist
-        """
-        response = self._get(
-            GET_ASSETS_FILE_SET_FILES_PATH.format(asset_id, file_sets_id),
-            **kwargs
-        )
-        return self.parse_response(response, FileSetsFilesResponse)
 
     def create_asset_format_component(
         self,
@@ -173,6 +149,13 @@ class FilesSpec(Spec):
         """
         resp = self._get(GET_ASSETS_FILE_PATH.format(asset_id, file_id), **kwargs)
         return self.parse_response(resp, File)
+
+    def get_asset_file_set_files(self, asset_id: str, file_sets_id: str, **kwargs) -> Response:
+        """
+        Retrieve files for a specific file set
+        """
+        response = self._get(GET_ASSETS_FILE_SET_FILES_PATH.format(asset_id, file_sets_id), **kwargs)
+        return self.parse_response(response, FileSetsFilesResponse)
 
     def get_asset_keyframe(self, asset_id: str, keyframe_id: str) -> Response:
         """Get a specific keyframe for an asset
@@ -464,7 +447,7 @@ class FilesSpec(Spec):
         Returns: Response(model=FileSet)
         """
         response = self._post(
-            GET_ASSETS_FILE_SET_PATH.format(asset_id),
+            GET_ASSETS_FILE_SETS_PATH.format(asset_id),
             json=body.model_dump(exclude_defaults=exclude_defaults),
             **kwargs,
         )
@@ -480,7 +463,7 @@ class FilesSpec(Spec):
         Returns:
             Response containing list of FileSets
         """
-        resp = self._get(GET_ASSETS_FILE_SET_PATH.format(asset_id), **kwargs)
+        resp = self._get(GET_ASSETS_FILE_SETS_PATH.format(asset_id), **kwargs)
         return self.parse_response(resp, FileSets)
 
     def get_asset_formats(self, asset_id: str, **kwargs) -> Response:

--- a/pythonik/tests/test_files.py
+++ b/pythonik/tests/test_files.py
@@ -478,7 +478,27 @@ def test_create_asset_format():
         client.files().create_asset_format(asset_id, body=model)
 
 
-def test_create_asset_fileset():
+def test_create_asset_file_sets():
+    with requests_mock.Mocker() as m:
+        app_id = str(uuid.uuid4())
+        auth_token = str(uuid.uuid4())
+        asset_id = str(uuid.uuid4())
+
+        model = FileSetCreate(
+            name=str(uuid.uuid4()),
+            format_id=str(uuid.uuid4()),
+            storage_id=str(uuid.uuid4()),
+        )
+        data = model.model_dump()
+
+        mock_address = FilesSpec.gen_url(GET_ASSETS_FILE_SETS_PATH.format(asset_id))
+        m.post(mock_address, json=data)
+
+        client = PythonikClient(app_id=app_id, auth_token=auth_token, timeout=3)
+        client.files().create_asset_file_sets(asset_id, body=model)
+
+
+def test_create_asset_filesets_deprecated():
     with requests_mock.Mocker() as m:
         app_id = str(uuid.uuid4())
         auth_token = str(uuid.uuid4())

--- a/pythonik/tests/test_files.py
+++ b/pythonik/tests/test_files.py
@@ -32,7 +32,7 @@ from pythonik.specs.files import (
     GET_ASSETS_FORMAT_PATH,
     DELETE_ASSETS_FILE_PATH,
     GET_ASSETS_FORMATS_PATH,
-    GET_ASSETS_FILE_SET_PATH,
+    GET_ASSETS_FILE_SETS_PATH,
     DELETE_ASSETS_FILE_SET_PATH,
     GET_ASSETS_FILE_SET_FILES_PATH,
     GET_ASSETS_FORMAT_COMPONENTS_PATH,
@@ -84,7 +84,7 @@ def test_get_asset_file_sets():
         m.get(mock_address, json=data)
 
         client = PythonikClient(app_id=app_id, auth_token=auth_token, timeout=3)
-        client.files().get_asset_file_sets(asset_id, file_sets_id)
+        client.files().get_asset_file_set_files(asset_id, file_sets_id)
 
 
 def test_get_proxy_by_proxy_id():
@@ -491,7 +491,7 @@ def test_create_asset_fileset():
         )
         data = model.model_dump()
 
-        mock_address = FilesSpec.gen_url(GET_ASSETS_FILE_SET_PATH.format(asset_id))
+        mock_address = FilesSpec.gen_url(GET_ASSETS_FILE_SETS_PATH.format(asset_id))
         m.post(mock_address, json=data)
 
         client = PythonikClient(app_id=app_id, auth_token=auth_token, timeout=3)
@@ -506,7 +506,7 @@ def test_get_asset_filesets():
 
         model = FileSets()
         data = model.model_dump()
-        mock_address = FilesSpec.gen_url(GET_ASSETS_FILE_SET_PATH.format(asset_id))
+        mock_address = FilesSpec.gen_url(GET_ASSETS_FILE_SETS_PATH.format(asset_id))
         m.get(mock_address, json=data)
         client = PythonikClient(app_id=app_id, auth_token=auth_token, timeout=3)
         params = {"per_page": 20}


### PR DESCRIPTION
- Rename GET_ASSETS_FILE_SET_PATH to GET_ASSETS_FILE_SETS_PATH for consistency
- Rename get_asset_file_sets() method to get_asset_file_set_files() to better reflect its functionality
- Update docstring to clarify the endpoint retrieves files for a specific file set
- Update related test cases and imports to match new naming

This change improves naming consistency and better describes the endpoint's purpose.