### PR TITLE
fix: remove default values from FileCreate model

### DIFF
--- a/pythonik/models/files/file.py
+++ b/pythonik/models/files/file.py
@@ -76,9 +76,9 @@ class FileCreate(File):
     name: str
     original_name: str
     size: int
-    type: str = FileType.FILE
+    type: str 
     directory_path: str = ""
-    status: str = FileStatus.CLOSED
+    status: str 
 
 
 class FileSet(BaseModel):

--- a/pythonik/tests/test_files.py
+++ b/pythonik/tests/test_files.py
@@ -4,6 +4,7 @@ from enum import Enum
 import pytest
 import requests_mock
 
+from pythonik.models.files.file import FileCreate, FileType, FileStatus
 from pythonik.client import PythonikClient
 from pythonik.exceptions import UnexpectedStorageMethodForProxy
 from pythonik.models.files.keyframe import Keyframe, Keyframes, Resolution
@@ -444,7 +445,8 @@ def test_create_asset_file():
         auth_token = str(uuid.uuid4())
         asset_id = str(uuid.uuid4())
         name = str(uuid.uuid4())
-
+        type = FileType.FILE.value
+        status = FileStatus.CLOSED.value
         model = FileCreate(
             file_set_id=str(uuid.uuid4()),
             format_id=str(uuid.uuid4()),
@@ -452,6 +454,8 @@ def test_create_asset_file():
             name=name,
             original_name=name,
             size=41,
+            type=type,
+            status=status,
         )
         data = model.model_dump()
 
@@ -642,3 +646,29 @@ def test_delete_asset_file_set_keep_source():
 
         # Mock 204 response
         m.delete(mock_address, status_code=204)
+
+
+# def test_file_create_serialization_behavior():
+#     file_data = FileCreate(
+#         file_set_id="fs123",
+#         format_id="fmt456",
+#         storage_id="stor789",
+#         name="test_file.txt",
+#         original_name="original_test_file.txt",
+#         size=1024,
+#         type=FileType.FILE.value,  # This has a default value
+#         directory_path="/path/to/dir",
+#         status=FileStatus.CLOSED.value  # This has a default value
+#     )
+
+#     # With exclude_defaults=True
+#     data_exclude_defaults = file_data.model_dump(exclude_defaults=True)
+#     # Fields with defaults will be excluded even if explicitly set
+#     # assert "type" not in data_exclude_defaults
+#     assert "status" not in data_exclude_defaults
+
+#     # With exclude_unset=True
+#     data_exclude_unset = file_data.model_dump(exclude_unset=True)
+#     # Fields that were explicitly set will be included, even if they match defaults
+#     assert "type" in data_exclude_unset
+#     assert "status" in data_exclude_unset


### PR DESCRIPTION
The FileCreate model had default values for `type` and `status` fields which
caused issues when using model_dump(exclude_defaults=True). Even when these
fields were explicitly set, they would be excluded from serialization if they
matched their default values.

Changes:
- Removed default FileType.FILE from type field
- Removed default FileStatus.CLOSED from status field
- Updated tests to explicitly set these required fields

This ensures that these important fields are always included in the serialized
output, regardless of their values.