### PR TITLE
feat: add collection content addition endpoint

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 2024-12-05 "Content Contentment" - version 1.1.0
+
+### Added
+- Add `add_content()` method to collections API for adding assets to collections
+- Add `AddContentResponse` model for handling collection content addition responses
+- Add tests for collection content addition functionality
+
+### Changed
+- Update collection content handling to use proper object type enums
+
 ## 2024-11-25 "Exclusion Delusion" - version 1.0.2
 
 ### Fixed

--- a/pythonik/models/assets/collections.py
+++ b/pythonik/models/assets/collections.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel, field_serializer, Field
 
 from pythonik.models.base import Status, PaginatedResponse
 from pythonik.models.files.keyframe import Keyframe
+from pythonik.models.base import ObjectType
 
 
 class CustomOrderStatus(str, Enum):
@@ -53,6 +54,12 @@ class Collection(BaseModel):
             return dt.isoformat()
         return None
 
+class Content(BaseModel):
+    object_id: str 
+    object_type: ObjectType
+
+class AddContentResponse(BaseModel):
+    pass
 
 class CollectionContentInfo(BaseModel):
     assets_count: int

--- a/pythonik/models/base.py
+++ b/pythonik/models/base.py
@@ -12,6 +12,9 @@ class Response(BaseModel):
     data: Any
     # data: Optional[BaseModel] = None
 
+class ObjectType(str, Enum):
+    ASSETS = "assets"
+    COLLECTIONS = "collections"
 
 class Status(str, Enum):
     ACTIVE = "ACTIVE"

--- a/pythonik/specs/collection.py
+++ b/pythonik/specs/collection.py
@@ -4,12 +4,15 @@ from pythonik.models.assets.collections import (
     Collection,
     CollectionContents,
     CollectionContentInfo,
+    Content,
+    AddContentResponse
 )
 
 BASE = "collections"
 GET_URL = BASE + "/{}/"
 GET_INFO = GET_URL + "content/info"
 GET_CONTENTS = GET_URL + "contents"
+POST_CONTENT = GET_CONTENTS
 
 
 class CollectionSpec(Spec):
@@ -122,3 +125,32 @@ class CollectionSpec(Spec):
             BASE, json=body.model_dump(exclude_defaults=exclude_defaults), **kwargs
         )
         return self.parse_response(response, Collection)
+    
+    def add_content(
+        self, collection_id: str, body: Content, exclude_defaults=True, **kwargs
+    ):
+        """Add an object to a collection.
+
+
+        Args:
+            collection_id (str): The ID of the collection to add content to
+            body (Content): The content object containing object_id and object_type
+            exclude_defaults (bool, optional): Whether to exclude default values from the request. Defaults to True.
+            **kwargs: Additional keyword arguments to pass to the request
+
+        Returns:
+            Response[Collection]: The updated collection object
+
+        Response Codes:
+            201: Content added successfully
+            400: Bad request
+            401: Token is invalid
+            404: Collection not found
+        """
+        response = self._post(
+            POST_CONTENT.format(collection_id),
+            json=body.model_dump(exclude_defaults=exclude_defaults),
+            **kwargs,
+        )
+        print(f"response: {response.json()}")
+        return self.parse_response(response, AddContentResponse)


### PR DESCRIPTION
- Add add_content() method to collections API for adding assets to collections
- Add AddContentResponse model for handling API responses
- Add ObjectType enum for content type validation
- Add unit tests and real API tests for content addition
- Update changelog for version 1.1.0