### PR TITLE
feat(metadata): add direct metadata update endpoint

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,11 +4,14 @@
 
 ### Added
 - Add `put_metadata_direct()` method for fast, admin-level metadata updates
-- Add comprehensive test suite for metadata direct updates including error cases
+- Add comprehensive test suite for metadata direct updates including error cases (400, 401, 403, 404)
 - Add documentation for direct metadata operations in `METADATA.md`
 
+### Changed
+- Improved docstring for `put_metadata_direct()` to clarify admin-only access and error cases
+
 ### Technical Details
-Introduced a new admin-level API endpoint for direct metadata updates that bypasses view validation for improved performance. This method should be used with caution as it can modify metadata even if the target object doesn't exist.
+Introduced a new admin-level API endpoint for direct metadata updates that bypasses view validation for improved performance. This method should be used with caution as it can modify metadata even if the target object doesn't exist. 
 
 ## 2024-12-05 "Content Contentment" - version 1.1.0
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 2024-12-10 "Metadata Mastery" - version 1.1.1
+
+### Added
+- Add `put_metadata_direct()` method for fast, admin-level metadata updates
+- Add comprehensive test suite for metadata direct updates including error cases
+- Add documentation for direct metadata operations in `METADATA.md`
+
+### Technical Details
+Introduced a new admin-level API endpoint for direct metadata updates that bypasses view validation for improved performance. This method should be used with caution as it can modify metadata even if the target object doesn't exist.
+
 ## 2024-12-05 "Content Contentment" - version 1.1.0
 
 ### Added

--- a/docs/METADATA.md
+++ b/docs/METADATA.md
@@ -1,0 +1,70 @@
+# Metadata Operations
+
+This document describes the metadata operations available in the Pythonik SDK.
+
+## Direct Metadata Updates
+
+The `put_metadata_direct` method allows for fast, direct updates to metadata without requiring a view. This method is designed for admin-level operations where performance is critical.
+
+### Example Usage
+
+```python
+from pythonik.client import PythonikClient
+from pythonik.models.mutation.metadata.mutate import UpdateMetadata
+
+# Initialize client
+client = PythonikClient(app_id="your_app_id", auth_token="your_admin_token")
+
+# Create metadata update
+metadata_values = {
+    "metadata_values": {
+        "custom_field": {
+            "field_values": [{"value": "new_value"}]
+        }
+    }
+}
+metadata = UpdateMetadata.model_validate(metadata_values)
+
+# For empty metadata updates:
+# metadata = UpdateMetadata.model_validate({"metadata_values": {}})
+
+# Update metadata directly
+response = client.metadata().put_metadata_direct(
+    object_type="assets",
+    object_id="your_asset_id",
+    metadata=metadata
+)
+
+if response.response.ok:
+    print(f"Metadata updated successfully: {response.data.metadata_values}")
+else:
+    print(f"Error updating metadata: {response.response.status_code}")
+```
+
+### Important Notes
+
+1. **Admin Access Required**: This method requires admin-level access token.
+2. **Performance vs Safety**: While this method is faster than view-based updates, it bypasses standard validation checks.
+3. **Data Integrity**: The method will write to the database even if the `object_id` doesn't exist, so use with caution.
+4. **Best Practices**:
+   - Always verify the object exists before updating its metadata
+   - Use standard view-based updates for non-admin operations
+   - Monitor responses for any errors
+   - Consider implementing additional validation in your application if needed
+
+### Response Structure
+
+A successful response will include:
+- `date_created`: Creation timestamp
+- `date_modified`: Last modification timestamp
+- `metadata_values`: Updated metadata values
+- `object_id`: Target object ID
+- `object_type`: Type of object
+- `version_id`: Version identifier
+
+### Error Responses
+
+- `400`: Bad request (invalid metadata format)
+- `401`: Invalid authentication token
+- `404`: Object type not found
+  

--- a/pythonik/specs/metadata.py
+++ b/pythonik/specs/metadata.py
@@ -77,6 +77,7 @@ class MetadataSpec(Spec):
         Raises:
             - 400 Bad request
             - 401 Token is invalid
+            - 403 Forbidden (non-admin user)
             - 404 Object not found
 
         Note:

--- a/pythonik/specs/metadata.py
+++ b/pythonik/specs/metadata.py
@@ -6,11 +6,13 @@ from pythonik.models.mutation.metadata.mutate import (
     UpdateMetadataResponse,
 )
 from pythonik.specs.base import Spec
-from typing import Literal
+from typing import Literal, Dict, Any
 
 ASSET_METADATA_FROM_VIEW_PATH = "assets/{}/views/{}"
 UPDATE_ASSET_METADATA = "assets/{}/views/{}/"
 ASSET_OBJECT_VIEW_PATH = "assets/{}/{}/{}/views/{}/"
+PUT_METADATA_DIRECT_PATH = "{}/{}/"
+
 
 ObjectType = Literal["segments"]
 
@@ -54,6 +56,36 @@ class MetadataSpec(Spec):
         """Given an asset's view id, update metadata in asset's view"""
         resp = self._put(
             UPDATE_ASSET_METADATA.format(asset_id, view_id), json=metadata.model_dump()
+        )
+
+        return self.parse_response(resp, UpdateMetadataResponse)
+    
+    def put_metadata_direct(self, object_type: str, object_id: str, metadata: UpdateMetadata) -> Response:
+        """Edit metadata values directly without a view.
+
+        Args:
+            object_type (str): The type of object to update metadata for
+            object_id (str): The unique identifier of the object
+            metadata (UpdateMetadata): Metadata values to update
+
+        Returns:
+            Response[UpdateMetadataResponse]
+
+        Required roles:
+            - admin_access
+
+        Raises:
+            - 400 Bad request
+            - 401 Token is invalid
+            - 404 Object not found
+
+        Note:
+            Use with caution. This method bypasses standard validation checks for speed,
+            and will write to the database even if the object_id doesn't exist. Admin
+            access required as this is a potentially dangerous operation.
+        """
+        resp = self._put(
+            PUT_METADATA_DIRECT_PATH.format(object_type, object_id), json=metadata.model_dump()
         )
 
         return self.parse_response(resp, UpdateMetadataResponse)

--- a/pythonik/tests/test_metadata.py
+++ b/pythonik/tests/test_metadata.py
@@ -1,8 +1,8 @@
 import uuid
-from venv import logger
 import requests_mock
 from pythonik.client import PythonikClient
 from requests import HTTPError
+from pythonik.models.base import ObjectType
 
 from pythonik.models.metadata.views import (
     FieldValue,
@@ -19,6 +19,7 @@ from pythonik.specs.metadata import (
     UPDATE_ASSET_METADATA,
     MetadataSpec,
     ASSET_OBJECT_VIEW_PATH,
+    PUT_METADATA_DIRECT_PATH
 )
 
 
@@ -195,3 +196,169 @@ def test_put_segment_view_metadata():
         client.metadata().put_segment_view_metadata(
             asset_id, segment_id, view_id, mutate_model
         )
+
+
+def test_put_metadata_direct():
+    """Test direct metadata update without a view."""
+    with requests_mock.Mocker() as m:
+        app_id = str(uuid.uuid4())
+        auth_token = str(uuid.uuid4())
+        object_type = ObjectType.ASSETS.value
+        object_id = str(uuid.uuid4())
+
+        # Create test metadata
+        metadata_values = {
+            "metadata_values": {
+                "test_field": {
+                    "field_values": [{"value": "test_value"}]
+                }
+            }
+        }
+        metadata = UpdateMetadata.model_validate(metadata_values)
+
+        # Expected response
+        response_data = {
+            "date_created": "2024-12-10T19:58:25Z",
+            "date_modified": "2024-12-10T19:58:25Z",
+            "metadata_values": metadata_values["metadata_values"],
+            "object_id": object_id,
+            "object_type": object_type,
+            "version_id": str(uuid.uuid4())
+        }
+
+        # Mock the PUT request
+        mock_address = MetadataSpec.gen_url(
+            PUT_METADATA_DIRECT_PATH.format(object_type, object_id)
+        )
+        m.put(mock_address, json=response_data)
+
+        # Make the request
+        client = PythonikClient(app_id=app_id, auth_token=auth_token, timeout=3)
+        response = client.metadata().put_metadata_direct(object_type, object_id, metadata)
+
+        # Verify response
+        assert response.response.ok
+        assert response.data.object_id == object_id
+        assert response.data.object_type == object_type
+        assert response.data.metadata_values == metadata_values["metadata_values"]
+
+
+def test_put_metadata_direct_unauthorized():
+    """Test direct metadata update with invalid token."""
+    with requests_mock.Mocker() as m:
+        app_id = str(uuid.uuid4())
+        auth_token = "invalid_token"
+        object_type = ObjectType.ASSETS.value
+        object_id = str(uuid.uuid4())
+
+        # Create empty metadata
+        metadata = UpdateMetadata.model_validate({"metadata_values": {}})
+
+        # Mock the PUT request to return 401
+        mock_address = MetadataSpec.gen_url(
+            PUT_METADATA_DIRECT_PATH.format(object_type, object_id)
+        )
+        m.put(mock_address, status_code=401)
+
+        # Make the request
+        client = PythonikClient(app_id=app_id, auth_token=auth_token, timeout=3)
+        response = client.metadata().put_metadata_direct(object_type, object_id, metadata)
+
+        # Verify response
+        assert not response.response.ok
+        assert response.response.status_code == 401
+
+
+def test_put_metadata_direct_404():
+    """Test direct metadata update with non-existent object."""
+    with requests_mock.Mocker() as m:
+        app_id = str(uuid.uuid4())
+        auth_token = str(uuid.uuid4())
+        object_type = ObjectType.ASSETS.value
+        object_id = str(uuid.uuid4())
+
+        # Create test metadata
+        metadata = UpdateMetadata.model_validate({"metadata_values": {}})
+
+        # Mock the PUT request to return 404
+        mock_address = MetadataSpec.gen_url(
+            PUT_METADATA_DIRECT_PATH.format(object_type, object_id)
+        )
+        m.put(mock_address, status_code=404, json={
+            "error": "Object not found",
+            "message": f"Object {object_id} of type {object_type} not found"
+        })
+
+        # Make the request
+        client = PythonikClient(app_id=app_id, auth_token=auth_token, timeout=3)
+        response = client.metadata().put_metadata_direct(object_type, object_id, metadata)
+
+        # Verify response
+        assert not response.response.ok
+        assert response.response.status_code == 404
+
+
+def test_put_metadata_direct_invalid_format():
+    """Test direct metadata update with invalid metadata format."""
+    with requests_mock.Mocker() as m:
+        app_id = str(uuid.uuid4())
+        auth_token = str(uuid.uuid4())
+        object_type = ObjectType.ASSETS.value
+        object_id = str(uuid.uuid4())
+
+        # Create test metadata with invalid format
+        metadata_values = {
+            "metadata_values": {
+                "test_field": {
+                    # Missing required field_values array
+                    "value": "test_value"
+                }
+            }
+        }
+        metadata = UpdateMetadata.model_validate({"metadata_values": {}})
+
+        # Mock the PUT request to return 400
+        mock_address = MetadataSpec.gen_url(
+            PUT_METADATA_DIRECT_PATH.format(object_type, object_id)
+        )
+        m.put(mock_address, status_code=400, json={
+            "error": "Invalid metadata format",
+            "message": "Metadata values must contain field_values array"
+        })
+
+        # Make the request
+        client = PythonikClient(app_id=app_id, auth_token=auth_token, timeout=3)
+        response = client.metadata().put_metadata_direct(object_type, object_id, metadata)
+
+        # Verify response
+        assert not response.response.ok
+        assert response.response.status_code == 400
+
+
+def test_put_metadata_direct_malformed():
+    """Test direct metadata update with malformed request."""
+    with requests_mock.Mocker() as m:
+        app_id = str(uuid.uuid4())
+        auth_token = str(uuid.uuid4())
+        object_type = "invalid_type"  # Invalid object type
+        object_id = str(uuid.uuid4())
+
+        # Create test metadata
+        metadata = UpdateMetadata.model_validate({"metadata_values": {}})
+
+        # Mock the PUT request to return 400
+        mock_address = MetadataSpec.gen_url(
+            PUT_METADATA_DIRECT_PATH.format(object_type, object_id)
+        )
+        m.put(mock_address, status_code=400, json={
+            "error": "Invalid request",
+            "message": "Invalid object type: must be one of [assets, segments, collections]"
+        })
+
+        # Make the request
+        client = PythonikClient(app_id=app_id, auth_token=auth_token, timeout=3)
+        response = client.metadata().put_metadata_direct(object_type, object_id, metadata)
+
+        # Verify response
+        assert not response.response.ok
+        assert response.response.status_code == 400


### PR DESCRIPTION
- Add put_metadata_direct() method for admin-level updates
- Add comprehensive test suite with error cases
- Update documentation in METADATA.md
- Update CHANGELOG.md to version 1.1.1

This introduces a new admin-level endpoint for fast metadata updates that bypasses view validation. The method includes proper error handling and documentation about its admin-only nature.