### PR TITLE
refactor(specs): improve type hints and standardize method signatures

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 2024-12-12 "Standardize" - version 1.3.0
+
+### Changed
+- Refactor specs to improve type hints and standardize method signatures
+- Add `Union[Model, Dict[str, Any]]` type hints to allow both Pydantic models and raw dicts
+- Introduce `_prepare_model_data` helper method to standardize model/dict handling
+- Improve docstrings with consistent Args/Returns sections
+- Add `**kwargs` propagation to all API methods
+- Make `exclude_defaults` parameter consistently typed as `bool`
+- Standardize error handling and response parsing
+
+### Technical Details
+This update focuses on refactoring the codebase to enhance type safety and consistency across method signatures, improving both maintainability and readability. The changes provide greater flexibility by allowing developers to either pre-instantiate Pydantic models or pass raw dictionaries directly to API methods, streamlining integration patterns based on their specific needs.
+
 ## 2024-12-10 "Metadata Mastery" - version 1.2.0
 
 ### Added

--- a/pythonik/specs/jobs.py
+++ b/pythonik/specs/jobs.py
@@ -1,4 +1,6 @@
 from enum import Enum
+from typing import Union, Dict, Any
+
 from pythonik.models.base import Response
 from pythonik.models.jobs.job_body import JobBody
 from pythonik.models.jobs.job_response import JobResponse
@@ -12,29 +14,55 @@ UPDATE_JOB_PATH = "jobs/{}"
 class JobSpec(Spec):
     server = "API/jobs/"
 
-    def create(self, body: JobBody, exclude_defaults=True, **kwargs) -> Response:
+    def create(
+        self,
+        body: Union[JobBody, Dict[str, Any]],
+        exclude_defaults: bool = True,
+        **kwargs
+    ) -> Response:
         """
         Create a job
-        """
 
+        Args:
+            body: Job creation parameters, either as JobBody model or dict
+            exclude_defaults: Whether to exclude default values when dumping Pydantic models
+            **kwargs: Additional kwargs to pass to the request
+
+        Returns:
+            Response[JobResponse]
+        """
+        json_data = self._prepare_model_data(body, exclude_defaults=exclude_defaults)
         resp = self._post(
             CREATE_JOB_PATH,
-            json=body.model_dump(exclude_defaults=exclude_defaults),
+            json=json_data,
             **kwargs
         )
 
         return self.parse_response(resp, JobResponse)
 
     def update(
-        self, job_id: str, body: JobBody, exclude_defaults=True, **kwargs
+        self,
+        job_id: str,
+        body: Union[JobBody, Dict[str, Any]],
+        exclude_defaults: bool = True,
+        **kwargs
     ) -> Response:
         """
-        update a job
-        """
+        Update a job
 
+        Args:
+            job_id: The ID of the job to update
+            body: Job update parameters, either as JobBody model or dict
+            exclude_defaults: Whether to exclude default values when dumping Pydantic models
+            **kwargs: Additional kwargs to pass to the request
+
+        Returns:
+            Response[JobResponse]
+        """
+        json_data = self._prepare_model_data(body, exclude_defaults=exclude_defaults)
         resp = self._patch(
             UPDATE_JOB_PATH.format(job_id),
-            json=body.model_dump(exclude_defaults=exclude_defaults),
+            json=json_data,
             **kwargs
         )
 

--- a/pythonik/specs/metadata.py
+++ b/pythonik/specs/metadata.py
@@ -6,7 +6,7 @@ from pythonik.models.mutation.metadata.mutate import (
     UpdateMetadataResponse,
 )
 from pythonik.specs.base import Spec
-from typing import Literal, Dict, Any
+from typing import Literal, Union, Dict, Any
 
 ASSET_METADATA_FROM_VIEW_PATH = "assets/{}/views/{}"
 UPDATE_ASSET_METADATA = "assets/{}/views/{}/"
@@ -21,19 +21,26 @@ class MetadataSpec(Spec):
     server = "API/metadata/"
 
     def get_asset_metadata(
-        self, asset_id: str, view_id: str, intercept_404: ViewMetadata = False
+        self, 
+        asset_id: str, 
+        view_id: str, 
+        intercept_404: ViewMetadata | bool = False,
+        **kwargs
     ) -> Response:
         """Given an asset id and the asset's view id, fetch metadata from the asset's view
 
-        intercept_404:
-            Iconik returns a 404 when a view has no metadata, intercept_404 will intercept that error
-            and return the ViewMetadata model provided
+        Args:
+            asset_id: The asset ID to get metadata for
+            view_id: The view ID to get metadata from
+            intercept_404: Iconik returns a 404 when a view has no metadata, intercept_404 will intercept that error
+                and return the ViewMetadata model provided
+            **kwargs: Additional kwargs to pass to the request
 
-            you can no longer call response.raise_for_status, so be careful using this.
+        Note:
+            You can no longer call response.raise_for_status, so be careful using this.
             Call raise_for_status_404 if you still want to raise status on 404 error
         """
-
-        resp = self._get(ASSET_METADATA_FROM_VIEW_PATH.format(asset_id, view_id))
+        resp = self._get(ASSET_METADATA_FROM_VIEW_PATH.format(asset_id, view_id), **kwargs)
 
         if intercept_404 and resp.status_code == 404:
             parsed_response = self.parse_response(resp, ViewMetadata)
@@ -51,22 +58,47 @@ class MetadataSpec(Spec):
         return self.parse_response(resp, ViewMetadata)
 
     def update_asset_metadata(
-        self, asset_id: str, view_id: str, metadata: UpdateMetadata
+        self, 
+        asset_id: str, 
+        view_id: str, 
+        metadata: Union[UpdateMetadata, Dict[str, Any]],
+        exclude_defaults: bool = True,
+        **kwargs
     ) -> Response:
-        """Given an asset's view id, update metadata in asset's view"""
+        """Given an asset's view id, update metadata in asset's view
+        
+        Args:
+            asset_id: The asset ID to update metadata for
+            view_id: The view ID to update metadata in
+            metadata: The metadata to update, either as UpdateMetadata model or dict
+            exclude_defaults: Whether to exclude default values when dumping Pydantic models
+            **kwargs: Additional kwargs to pass to the request
+        """
+        json_data = self._prepare_model_data(metadata, exclude_defaults=exclude_defaults)
         resp = self._put(
-            UPDATE_ASSET_METADATA.format(asset_id, view_id), json=metadata.model_dump()
+            UPDATE_ASSET_METADATA.format(asset_id, view_id), 
+            json=json_data,
+            **kwargs
         )
 
         return self.parse_response(resp, UpdateMetadataResponse)
     
-    def put_metadata_direct(self, object_type: str, object_id: str, metadata: UpdateMetadata) -> Response:
+    def put_metadata_direct(
+        self, 
+        object_type: str, 
+        object_id: str, 
+        metadata: Union[UpdateMetadata, Dict[str, Any]],
+        exclude_defaults: bool = True,
+        **kwargs
+    ) -> Response:
         """Edit metadata values directly without a view.
 
         Args:
-            object_type (str): The type of object to update metadata for
-            object_id (str): The unique identifier of the object
-            metadata (UpdateMetadata): Metadata values to update
+            object_type: The type of object to update metadata for
+            object_id: The unique identifier of the object
+            metadata: Metadata values to update, either as UpdateMetadata model or dict
+            exclude_defaults: Whether to exclude default values when dumping Pydantic models
+            **kwargs: Additional kwargs to pass to the request
 
         Returns:
             Response[UpdateMetadataResponse]
@@ -85,23 +117,100 @@ class MetadataSpec(Spec):
             and will write to the database even if the object_id doesn't exist. Admin
             access required as this is a potentially dangerous operation.
         """
+        json_data = self._prepare_model_data(metadata, exclude_defaults=exclude_defaults)
         resp = self._put(
-            PUT_METADATA_DIRECT_PATH.format(object_type, object_id), json=metadata.model_dump()
+            PUT_METADATA_DIRECT_PATH.format(object_type, object_id),
+            json=json_data,
+            **kwargs
         )
 
         return self.parse_response(resp, UpdateMetadataResponse)
 
     def put_object_view_metadata(
-        self, asset_id: str, object_type: ObjectType, object_id: str, view_id: str, metadata: UpdateMetadata
+        self,
+        asset_id: str,
+        object_type: ObjectType,
+        object_id: str,
+        view_id: str,
+        metadata: Union[UpdateMetadata, Dict[str, Any]],
+        exclude_defaults: bool = True,
+        **kwargs
     ) -> Response:
-        """Put metadata for a specific sub-object view of an asset"""
+        """Put metadata for a specific sub-object view of an asset
+        
+        Args:
+            asset_id: The asset ID to update metadata for
+            object_type: The type of object to update metadata for
+            object_id: The object ID to update metadata for
+            view_id: The view ID to update metadata in
+            metadata: The metadata to update, either as UpdateMetadata model or dict
+            exclude_defaults: Whether to exclude default values when dumping Pydantic models
+            **kwargs: Additional kwargs to pass to the request
+        """
+        json_data = self._prepare_model_data(metadata, exclude_defaults=exclude_defaults)
         endpoint = ASSET_OBJECT_VIEW_PATH.format(asset_id, object_type, object_id, view_id)
-        resp = self._put(endpoint, json=metadata.model_dump())
+        resp = self._put(
+            endpoint,
+            json=json_data,
+            **kwargs
+        )
 
         return self.parse_response(resp, UpdateMetadataResponse)
 
     def put_segment_view_metadata(
-        self, asset_id: str, segment_id: str, view_id: str, metadata: UpdateMetadata
+        self,
+        asset_id: str,
+        segment_id: str,
+        view_id: str,
+        metadata: Union[UpdateMetadata, Dict[str, Any]],
+        exclude_defaults: bool = True,
+        **kwargs
     ) -> Response:
-        """Put metadata for a segment of an asset"""
-        return self.put_object_view_metadata(asset_id, "segments", segment_id, view_id, metadata)
+        """Put metadata for a segment view (backwards compatibility wrapper)
+        
+        Args:
+            asset_id: The asset ID to update metadata for
+            segment_id: The segment ID to update metadata for
+            view_id: The view ID to update metadata in
+            metadata: The metadata to update, either as UpdateMetadata model or dict
+            exclude_defaults: Whether to exclude default values when dumping Pydantic models
+            **kwargs: Additional kwargs to pass to the request
+        """
+        return self.put_object_view_metadata(
+            asset_id=asset_id,
+            object_type="segments",
+            object_id=segment_id,
+            view_id=view_id,
+            metadata=metadata,
+            exclude_defaults=exclude_defaults,
+            **kwargs
+        )
+
+    def put_segment_metadata(
+        self, 
+        asset_id: str, 
+        segment_id: str, 
+        view_id: str, 
+        metadata: Union[UpdateMetadata, Dict[str, Any]], 
+        exclude_defaults: bool = True,
+        **kwargs
+    ) -> Response:
+        """Put metadata for a segment of an asset
+        
+        Args:
+            asset_id: The asset ID to update metadata for
+            segment_id: The segment ID to update metadata for
+            view_id: The view ID to update metadata in
+            metadata: The metadata to update, either as UpdateMetadata model or dict
+            exclude_defaults: Whether to exclude default values when dumping Pydantic models
+            **kwargs: Additional kwargs to pass to the request
+        """
+        return self.put_object_view_metadata(
+            asset_id, 
+            "segments", 
+            segment_id, 
+            view_id, 
+            metadata, 
+            exclude_defaults=exclude_defaults,
+            **kwargs
+        )

--- a/pythonik/specs/search.py
+++ b/pythonik/specs/search.py
@@ -1,3 +1,5 @@
+from typing import Union, Dict, Any
+
 from pythonik.models.base import Response
 from pythonik.models.search.search_body import SearchBody
 from pythonik.models.search.search_response import SearchResponse
@@ -11,12 +13,26 @@ class SearchSpec(Spec):
     server = "API/search/"
 
     def search(
-        self, search_body: SearchBody, exclude_defaults=True, **kwargs
-    ) -> Response:
-        """search iconik"""
+        self,
+        search_body: Union[SearchBody, Dict[str, Any]],
+        exclude_defaults: bool = True,
+        **kwargs
+    ) -> Response:  # Response.data will be SearchResponse
+        """
+        Search iconik
+
+        Args:
+            search_body: Search parameters, either as SearchBody model or dict
+            exclude_defaults: Whether to exclude default values when dumping Pydantic models
+            **kwargs: Additional kwargs to pass to the request
+
+        Returns:
+            Response with SearchResponse data model
+        """
+        json_data = self._prepare_model_data(search_body, exclude_defaults=exclude_defaults)
         resp = self._post(
             SEARCH_PATH,
-            json=search_body.model_dump(exclude_defaults=exclude_defaults),
+            json=json_data,
             **kwargs
         )
         return self.parse_response(resp, SearchResponse)


### PR DESCRIPTION
- Add Union[Model, Dict[str, Any]] type hints to allow both Pydantic models and raw dicts
- Add _prepare_model_data helper method to standardize model/dict handling
- Improve docstrings with consistent Args/Returns sections
- Add **kwargs propagation to all API methods
- Make exclude_defaults parameter consistently typed as bool
- Standardize error handling and response parsing