### PR TITLE
feat(metadata): Add complete metadata view management functionality 

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,7 +16,7 @@
 - Add comprehensive test coverage for all view operations
 
 ### Technical Details
-This update introduces complete metadata view management capabilities, allowing programmatic control over view creation, modification, and deletion. The implementation supports both Pydantic models and raw dictionaries as inputs, maintaining consistency with existing API patterns. All operations include proper error handling and role-based access control.
+This update introduces complete metadata view management capabilities, allowing programmatic control over view creation, modification, and deletion. The implementation supports both Pydantic models and raw dictionaries as inputs, maintaining consistency with existing API patterns. 
 
 ## 2024-12-12 "Standardize" - version 1.3.0
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 2024-12-20 "View Management" - version 1.4.0
+
+### Added
+- Add comprehensive view management functionality:
+  - `create_view()` for creating new metadata views
+  - `get_views()` for listing all views
+  - `update_view()` for partial view updates
+  - `replace_view()` for full view replacements
+  - `delete_view()` for removing views
+- Add view-related models:
+  - `ViewResponse` and `ViewListResponse` for API responses
+  - `ViewField` and `ViewOption` for view configuration
+  - `CreateViewRequest` and `UpdateViewRequest` for mutations
+- Add comprehensive test coverage for all view operations
+
+### Technical Details
+This update introduces complete metadata view management capabilities, allowing programmatic control over view creation, modification, and deletion. The implementation supports both Pydantic models and raw dictionaries as inputs, maintaining consistency with existing API patterns. All operations include proper error handling and role-based access control.
+
 ## 2024-12-12 "Standardize" - version 1.3.0
 
 ### Changed

--- a/pythonik/models/metadata/view_responses.py
+++ b/pythonik/models/metadata/view_responses.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from typing import List, Optional
+
+from pydantic import BaseModel
+
+from pythonik.models.metadata.views import ViewField
+
+
+class ViewResponse(BaseModel):
+    """Response model for a view."""
+    id: str
+    name: str
+    description: Optional[str] = None
+    date_created: str
+    date_modified: str
+    view_fields: List[ViewField]

--- a/pythonik/models/metadata/view_responses.py
+++ b/pythonik/models/metadata/view_responses.py
@@ -4,6 +4,7 @@ from typing import List, Optional
 
 from pydantic import BaseModel
 
+from pythonik.models.base import PaginatedResponse
 from pythonik.models.metadata.views import ViewField
 
 
@@ -15,3 +16,8 @@ class ViewResponse(BaseModel):
     date_created: str
     date_modified: str
     view_fields: List[ViewField]
+
+
+class ViewListResponse(PaginatedResponse):
+    """Response model for list of views."""
+    objects: List[ViewResponse]

--- a/pythonik/models/metadata/views.py
+++ b/pythonik/models/metadata/views.py
@@ -23,6 +23,54 @@ class MetadataValues(RootModel):
         return self.root[item]
 
 
+class ViewOption(BaseModel):
+    """Option for a view field."""
+    label: str
+    value: str
+
+
+class ViewField(BaseModel):
+    """Field configuration for a view."""
+    name: str
+    label: str
+    auto_set: Optional[bool] = False
+    date_created: Optional[str] = None
+    date_modified: Optional[str] = None
+    description: Optional[str] = None
+    external_id: Optional[str] = None
+    field_type: Optional[str] = None
+    hide_if_not_set: Optional[bool] = False
+    is_block_field: Optional[bool] = False
+    is_warning_field: Optional[bool] = False
+    mapped_field_name: Optional[str] = None
+    max_value: Optional[int] = None
+    min_value: Optional[int] = None
+    multi: Optional[bool] = False
+    options: Optional[List[ViewOption]] = None
+    read_only: Optional[bool] = False
+    representative: Optional[bool] = False
+    required: Optional[bool] = False
+    sortable: Optional[bool] = False
+    source_url: Optional[str] = None
+    use_as_facet: Optional[bool] = False
+
+
+class CreateViewRequest(BaseModel):
+    """Request model for creating a view."""
+    name: str
+    description: Optional[str] = None
+    view_fields: List[ViewField]
+
+
+class View(BaseModel):
+    id: str
+    name: str
+    description: Optional[str] = None
+    date_created: str
+    date_modified: str
+    view_fields: List[ViewField]
+
+
 class ViewMetadata(BaseModel):
     date_created: Optional[str] = ""
     date_modified: Optional[str] = ""

--- a/pythonik/models/metadata/views.py
+++ b/pythonik/models/metadata/views.py
@@ -62,6 +62,13 @@ class CreateViewRequest(BaseModel):
     view_fields: List[ViewField]
 
 
+class UpdateViewRequest(BaseModel):
+    """Request model for updating a view."""
+    name: Optional[str] = None
+    description: Optional[str] = None
+    view_fields: Optional[List[ViewField]] = None
+
+
 class View(BaseModel):
     id: str
     name: str

--- a/pythonik/specs/metadata.py
+++ b/pythonik/specs/metadata.py
@@ -283,6 +283,39 @@ class MetadataSpec(Spec):
         resp = self._patch(UPDATE_VIEW_PATH.format(view_id=view_id), json=json_data, **kwargs)
         return self.parse_response(resp, ViewResponse)
 
+    def replace_view(
+        self,
+        view_id: str,
+        view: Union[CreateViewRequest, Dict[str, Any]],
+        exclude_defaults: bool = True,
+        **kwargs
+    ) -> Response:
+        """Replace an existing view in Iconik with a new one.
+        
+        Unlike update_view which allows partial updates, this method requires all fields
+        to be specified as it completely replaces the view.
+        
+        Args:
+            view_id: ID of the view to replace
+            view: The complete new view data, either as CreateViewRequest model or dict
+            exclude_defaults: Whether to exclude default values when dumping Pydantic models
+            **kwargs: Additional kwargs to pass to the request
+            
+        Required roles:
+            - can_write_metadata_views
+            
+        Returns:
+            Response: The replaced view
+            
+        Raises:
+            - 400 Bad request
+            - 401 Token is invalid
+            - 404 Metadata view doesn't exist
+        """
+        json_data = self._prepare_model_data(view, exclude_defaults=exclude_defaults)
+        resp = self._put(UPDATE_VIEW_PATH.format(view_id=view_id), json=json_data, **kwargs)
+        return self.parse_response(resp, ViewResponse)
+
     def get_views(self, **kwargs) -> Response:
         """List all views defined in the system.
         

--- a/pythonik/specs/metadata.py
+++ b/pythonik/specs/metadata.py
@@ -334,3 +334,24 @@ class MetadataSpec(Spec):
         """
         resp = self._get(VIEWS_BASE, **kwargs)
         return self.parse_response(resp, ViewListResponse)
+
+    def delete_view(self, view_id: str, **kwargs) -> Response:
+        """Delete a view from Iconik.
+        
+        Args:
+            view_id: ID of the view to delete
+            **kwargs: Additional kwargs to pass to the request
+            
+        Required roles:
+            - can_delete_metadata_views
+            
+        Returns:
+            Response: Empty response with 204 status code
+            
+        Raises:
+            - 400 Bad request
+            - 401 Token is invalid
+            - 404 Metadata view doesn't exist
+        """
+        resp = self._delete(DELETE_VIEW_PATH.format(view_id=view_id), **kwargs)
+        return self.parse_response(resp, None)

--- a/pythonik/specs/metadata.py
+++ b/pythonik/specs/metadata.py
@@ -2,7 +2,6 @@ from loguru import logger
 from pythonik.models.base import Response
 from pythonik.models.metadata.views import ViewMetadata, CreateViewRequest, UpdateViewRequest
 from pythonik.models.metadata.view_responses import ViewResponse, ViewListResponse
-from pythonik.models.metadata.view_responses import ViewListResponse
 from pythonik.models.mutation.metadata.mutate import (
     UpdateMetadata,
     UpdateMetadataResponse,
@@ -334,6 +333,37 @@ class MetadataSpec(Spec):
         """
         resp = self._get(VIEWS_BASE, **kwargs)
         return self.parse_response(resp, ViewListResponse)
+
+    def get_view(
+        self,
+        view_id: str,
+        merge_fields: bool = None,
+        **kwargs
+    ) -> Response:
+        """Get a specific view from Iconik.
+        
+        Args:
+            view_id: ID of the view to retrieve
+            merge_fields: Optional boolean to control field merging
+            **kwargs: Additional kwargs to pass to the request
+            
+        Required roles:
+            - can_read_metadata_views
+            
+        Returns:
+            Response: The requested view
+            
+        Raises:
+            - 400 Bad request
+            - 401 Token is invalid
+            - 404 Metadata view doesn't exist
+        """
+        params = {}
+        if merge_fields is not None:
+            params["merge_fields"] = merge_fields
+            
+        resp = self._get(GET_VIEW_PATH.format(view_id=view_id), params=params, **kwargs)
+        return self.parse_response(resp, ViewResponse)
 
     def delete_view(self, view_id: str, **kwargs) -> Response:
         """Delete a view from Iconik.


### PR DESCRIPTION
Adds support for creating metadata views via the API, including:
- New models: ViewField, ViewOption, CreateViewRequest, View
- New endpoint: create_view() method in MetadataSpec
- Comprehensive test coverage for view creation including error cases
- Support for both Pydantic models and raw dict inputs

Required role: can_write_metadata_views