### PR TITLE
Feature/alternative-base-url

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,25 @@ data_as_dict = data.model_dump()
 data_as_json = data.model_dump_json()
 ```
 
+### Connecting to Different Iconik Environments
+
+By default, Pythonik connects to the standard Iconik environment (`https://app.iconik.io`). To connect to a different Iconik environment, you can specify the base URL when initializing the client:
+
+```python
+from pythonik.client import PythonikClient
+
+client = PythonikClient(
+    app_id=app_id,
+    auth_token=auth_token,
+    timeout=10,
+    base_url="https://your-custom-iconik-instance.com"
+)
+```
+
+This is useful when working with:
+- AWS Iconik deployments
+- Custom Iconik deployments (assuming this is possible)
+
 Checkout the [API reference](./docs/API_REFERENCE.md) and [advanced usage guide](./docs/ADVANCED_USAGE.md) to see all you can do with Pythonik.
 
 ## Publishing to PyPI (for maintainers) 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 2024-12-24 "Alternative Environments" - version 1.5.0
+
+### Added
+- Add configurable base URL support:
+  - New `base_url` parameter in `PythonikClient` constructor
+  - Support for AWS Iconik deployments
+  - Support for custom Iconik deployments
+- Propagate base URL through all spec classes
+- Add documentation for connecting to different Iconik environments
+
+### Technical Details
+This update enables connecting to different Iconik environments by making the base URL configurable. The implementation maintains consistent client behavior across all API operations while allowing flexibility in the target environment. This is particularly useful for AWS Iconik deployments.
+
 ## 2024-12-20 "View Management" - version 1.4.0
 
 ### Added

--- a/pythonik/client.py
+++ b/pythonik/client.py
@@ -16,8 +16,9 @@ class PythonikClient:
     Iconik Client
     """
 
-    def __init__(self, app_id: str, auth_token: str, timeout: int):
+    def __init__(self, app_id: str, auth_token: str, timeout: int, base_url: str  = "https://app.iconik.io" ):
         self.session = Session()
+        self.base_url = base_url
         retry_strategy = Retry(
             total=4,  # Maximum number of retries
             backoff_factor=3,
@@ -33,19 +34,19 @@ class PythonikClient:
         self.timeout = timeout
 
     def collections(self):
-        return CollectionSpec(self.session, self.timeout)
+        return CollectionSpec(self.session, self.timeout, self.base_url)
 
     def assets(self):
-        return AssetSpec(self.session, self.timeout)
+        return AssetSpec(self.session, self.timeout, self.base_url)
 
     def files(self):
-        return FilesSpec(self.session, self.timeout)
+        return FilesSpec(self.session, self.timeout, self.base_url)
 
     def metadata(self):
-        return MetadataSpec(self.session, self.timeout)
+        return MetadataSpec(self.session, self.timeout, self.base_url)
 
     def search(self):
-        return SearchSpec(self.session, self.timeout)
+        return SearchSpec(self.session, self.timeout, self.base_url)
 
     def jobs(self):
-        return JobSpec(self.session, self.timeout)
+        return JobSpec(self.session, self.timeout, self.base_url)

--- a/pythonik/specs/assets.py
+++ b/pythonik/specs/assets.py
@@ -25,9 +25,9 @@ PURGE_ALL_URL = DELETE_QUEUE + "/purge/all/"
 class AssetSpec(Spec):
     server = "API/assets/"
 
-    def __init__(self, session, timeout=3):
-        super().__init__(session, timeout)
+    def __init__(self, session, timeout=3, base_url: str ="https://app.iconik.io"):
         self._collection_spec = CollectionSpec(session=session, timeout=timeout)
+        return super().__init__(session, timeout, base_url)
 
     @property
     def collections(self) -> CollectionSpec:

--- a/pythonik/specs/base.py
+++ b/pythonik/specs/base.py
@@ -8,13 +8,19 @@ from pythonik.models.base import Response as PythonikResponse
 
 class Spec:
     server: str = ""
-    api_version = "v1"
-    base_url = "https://app.iconik.io"
+    api_version: str = "v1"
+    base_url: str = "https://app.iconik.io"
 
-    def __init__(self, session: Session, timeout: int = 3):
+    @classmethod
+    def set_class_attribute(cls, name, value):
+        setattr(cls, name, value)
+
+    def __init__(self, session: Session, timeout: int = 3, base_url: str = "https://app.iconik.io"):
         self.session = session
         self.timeout = timeout
-
+        self.set_class_attribute("base_url", base_url)
+    
+        
     @staticmethod
     def _prepare_model_data(data: Union[BaseModel, Dict[str, Any]], exclude_defaults: bool = True) -> Dict[str, Any]:
         """

--- a/pythonik/tests/test_base_url.py
+++ b/pythonik/tests/test_base_url.py
@@ -1,0 +1,99 @@
+import uuid
+import pytest
+from pythonik.client import PythonikClient
+from pythonik.specs.assets import AssetSpec
+from pythonik.specs.collection import CollectionSpec
+from pythonik.specs.files import FilesSpec
+from pythonik.specs.jobs import JobSpec
+from pythonik.specs.metadata import MetadataSpec
+from pythonik.specs.search import SearchSpec
+from pythonik.specs.base import Spec
+
+SPECS = [
+    AssetSpec,
+    CollectionSpec,
+    FilesSpec,
+    JobSpec,
+    MetadataSpec,
+    SearchSpec
+]
+
+def test_default_base_url():
+    """Test that all specs have the default base URL by default"""
+    app_id = str(uuid.uuid4())
+    auth_token = str(uuid.uuid4())
+    client = PythonikClient(app_id=app_id, auth_token=auth_token, timeout=3)
+    
+    for spec_class in SPECS:
+        spec = spec_class(client.session, timeout=3)
+        assert spec.base_url == "https://app.iconik.io"
+        # Test that gen_url includes the base_url
+        test_path = "test/path"
+        url = spec.gen_url(test_path)
+        assert url.startswith("https://app.iconik.io/")
+        assert test_path in url
+
+def test_alternative_base_url():
+    """Test that all specs accept and use an alternative base URL"""
+    app_id = str(uuid.uuid4())
+    auth_token = str(uuid.uuid4())
+    alt_base_url = "https://alt.iconik.io"
+    client = PythonikClient(app_id=app_id, auth_token=auth_token, timeout=3)
+    
+    for spec_class in SPECS:
+        spec = spec_class(client.session, timeout=3, base_url=alt_base_url)
+        assert spec.base_url == alt_base_url
+        # Test that gen_url includes the alternative base_url
+        test_path = "test/path"
+        url = spec.gen_url(test_path)
+        assert url.startswith(f"{alt_base_url}/")
+        assert test_path in url
+
+def test_multiple_instances_share_base_url():
+    """Test that multiple instances of the same spec share the base URL"""
+    app_id = str(uuid.uuid4())
+    auth_token = str(uuid.uuid4())
+    alt_base_url = "https://alt.iconik.io"
+    client = PythonikClient(app_id=app_id, auth_token=auth_token, timeout=3)
+
+    for name, spec in vars(client).items():
+        if isinstance(spec, Spec):
+            try:
+                # Create first instance with alternative base URL
+                spec1 = type(spec)(client.session, timeout=3, base_url=alt_base_url)
+                assert spec1.base_url == alt_base_url
+
+                # Create second instance without specifying base URL
+                spec2 = type(spec)(client.session, timeout=3)
+                assert spec2.base_url == alt_base_url  # Should inherit the changed base URL
+            except Exception as e:
+                print(f"Failed for spec {name}: {e}")
+                raise
+            finally:
+                # Reset base URL for next spec test
+                spec_class = type(spec)
+                spec_class.set_class_attribute("base_url", "https://app.iconik.io")
+
+def test_base_url_inheritance():
+    """Test that subclasses inherit the base URL from parent class"""
+    app_id = str(uuid.uuid4())
+    auth_token = str(uuid.uuid4())
+    alt_base_url = "https://alt.iconik.io"
+    client = PythonikClient(app_id=app_id, auth_token=auth_token, timeout=3)
+
+    try:
+        # Set base_url on each spec class
+        for spec_class in SPECS:
+            spec_class.set_class_attribute("base_url", alt_base_url)
+            # Debug: check the base_url right after setting it
+            print(f"{spec_class.__name__} base_url: {spec_class.base_url}")
+
+        # Test each spec class
+        for spec_class in SPECS:
+            # Create new instance without specifying base URL
+            spec = spec_class(client.session, 3, alt_base_url)
+            assert spec.base_url == alt_base_url
+    finally:
+        # Reset base URL for each spec class
+        for spec_class in SPECS:
+            spec_class.set_class_attribute("base_url", "https://app.iconik.io")


### PR DESCRIPTION
feat: add configurable base URL for AWS/custom Iconik deployments

This PR adds support for configurable base URLs in the Pythonik client, enabling 
connection to AWS Iconik deployments and potentially custom instances.

Changes:
- Add base_url parameter to PythonikClient constructor
- Propagate base_url through all spec classes
- Add documentation for alternative Iconik environments
- Update changelog for version 1.5.0

This feature is particularly important for users working with AWS-hosted Iconik 
instances, allowing them to specify their deployment-specific endpoint while 
maintaining consistent client behavior.