### PR TITLE
feat(assets): add DELETE endpoint for single asset

### DIFF
--- a/docs/DELETE.md
+++ b/docs/DELETE.md
@@ -1,0 +1,77 @@
+# Deleting Assets in Pythonik
+
+This guide explains how to delete assets using the Pythonik client library.
+
+## Prerequisites
+
+- A valid Iconik App ID and Auth Token
+- The `pythonik` library installed
+- Appropriate permissions (`can_delete_assets` role)
+
+## Basic Usage
+
+To delete a single asset, you'll need the asset's ID. Here's a basic example:
+
+```python
+from pythonik.client import PythonikClient
+
+# Initialize the client
+client = PythonikClient(
+    app_id="your_app_id",
+    auth_token="your_auth_token"
+)
+
+# Delete an asset
+response = client.assets.delete(asset_id="your_asset_id")
+
+# Check if deletion was successful
+if response.status_code == 204:
+    print("Asset deleted successfully")
+```
+
+## Error Handling
+
+The delete operation may raise several types of errors:
+
+- `400`: Bad request - The request was malformed
+- `401`: Invalid token - Authentication failed
+- `403`: Forbidden - User lacks the required permissions
+- `404`: Asset not found - The specified asset ID doesn't exist
+
+Here's an example with error handling:
+
+```python
+from pythonik.client import PythonikClient
+from pythonik.exceptions import (
+    BadRequestError,
+    UnauthorizedError,
+    ForbiddenError,
+    NotFoundError
+)
+
+client = PythonikClient(app_id="your_app_id", auth_token="your_auth_token")
+
+try:
+    response = client.assets.delete(asset_id="your_asset_id")
+    print("Asset deleted successfully")
+except BadRequestError:
+    print("Invalid request format")
+except UnauthorizedError:
+    print("Invalid authentication credentials")
+except ForbiddenError:
+    print("Insufficient permissions")
+except NotFoundError:
+    print("Asset not found")
+```
+
+## Related Operations
+
+- For bulk deletion of assets, see `client.assets.bulk_delete()`
+- For permanent deletion of assets in the delete queue, see `client.assets.permanently_delete()`
+
+## Best Practices
+
+1. Always verify that you have the correct asset ID before deletion
+2. Implement proper error handling
+3. Consider using bulk delete operations when removing multiple assets
+4. Keep track of deleted assets for audit purposes

--- a/pythonik/specs/assets.py
+++ b/pythonik/specs/assets.py
@@ -319,3 +319,26 @@ class AssetSpec(Spec):
         )
         # Since this returns 202 with no content, we don't need a response model
         return self.parse_response(response, None)
+
+    def delete(self, asset_id: str, **kwargs) -> Response:
+        """
+        Delete a particular asset by id
+
+        Args:
+            asset_id: ID of the asset to delete
+            **kwargs: Additional kwargs to pass to the request
+
+        Returns:
+            Response with no data model (204 status code)
+
+        Required roles:
+            - can_delete_assets
+
+        Raises:
+            400 Bad request
+            401 Token is invalid
+            403 Forbidden
+            404 Asset does not exist
+        """
+        response = self._delete(GET_URL.format(asset_id), **kwargs)
+        return self.parse_response(response, model=None)

--- a/pythonik/tests/test_assets.py
+++ b/pythonik/tests/test_assets.py
@@ -210,3 +210,19 @@ def test_create_version_from_asset():
         client.assets().create_version_from_asset(
             asset_id=asset_id, source_asset_id=source_asset_id, body=model
         )
+
+
+def test_delete_asset():
+    with requests_mock.Mocker() as m:
+        app_id = str(uuid.uuid4())
+        auth_token = str(uuid.uuid4())
+        asset_id = str(uuid.uuid4())
+
+        mock_address = AssetSpec.gen_url(GET_URL.format(asset_id))
+        m.delete(mock_address, status_code=204)
+
+        client = PythonikClient(app_id=app_id, auth_token=auth_token, timeout=3)
+        client.assets().delete(asset_id)
+
+        assert m.call_count == 1
+        assert m.last_request.method == "DELETE"


### PR DESCRIPTION
- Implement DELETE /v1/assets/{asset_id}/ endpoint
- Add test coverage for asset deletion
- Support 204 response for successful deletion
- Handle required can_delete_assets role