### PR TITLE
fix: update version endpoints to use correct response model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -159,5 +159,8 @@ cython_debug/
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 .idea/
 
+# Integration tests
+pythonik/tests/test_*_integration.py
+
 # Misc.
 IGNORE

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2025-01-10 "BugFix" - version 1.9.2
+
+### Fixed
+- Fixed response model handling for version endpoints to use AssetVersionResponse:
+  - `partial_update_version()`
+  - `update_version()`
+
 ## 2025-01-10 "Version Management" - version 1.9.1
 
 ### Fixed

--- a/pythonik/specs/assets.py
+++ b/pythonik/specs/assets.py
@@ -366,7 +366,7 @@ class AssetSpec(Spec):
             VERSION_URL.format(asset_id, version_id),
             json=self._prepare_model_data(body)
         )
-        return self.parse_response(response, AssetVersion)
+        return self.parse_response(response, AssetVersionResponse)
 
     def update_version(
         self,
@@ -387,7 +387,7 @@ class AssetSpec(Spec):
             VERSION_URL.format(asset_id, version_id),
             json=self._prepare_model_data(body)
         )
-        return self.parse_response(response, AssetVersion)
+        return self.parse_response(response, AssetVersionResponse)
 
     def promote_version(
         self,


### PR DESCRIPTION
- Fix partial_update_version() and update_version() to use AssetVersionResponse
- Update CHANGELOG.md for version 1.9.2
- Add integration test files to .gitignore