### PR TITLE
fix: update version endpoints to use correct response model

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2025-01-10 "Test Updates" - version 1.9.3
+
+### Fixed
+- Updated unit tests for version endpoints to correctly mock AssetVersionResponse model
+- Fixed test assertions to match API response structure
+
 ## 2025-01-10 "BugFix" - version 1.9.2
 
 ### Fixed

--- a/pythonik/tests/test_assets.py
+++ b/pythonik/tests/test_assets.py
@@ -254,9 +254,14 @@ def test_partial_update_version():
             transcribe_status="N/A",
             version_number=0
         )
+        response = AssetVersionResponse(
+            asset_id=asset_id,
+            system_domain_id=str(uuid.uuid4()),
+            versions=[model]
+        )
         mock_address = AssetSpec.gen_url(VERSION_URL.format(asset_id, version_id))
 
-        m.patch(mock_address, json=model.model_dump())
+        m.patch(mock_address, json=response.model_dump())
         client = PythonikClient(app_id=app_id, auth_token=auth_token, timeout=3)
 
         client.assets().partial_update_version(
@@ -288,9 +293,14 @@ def test_update_version():
             transcribe_status="N/A",
             version_number=0
         )
+        response = AssetVersionResponse(
+            asset_id=asset_id,
+            system_domain_id=str(uuid.uuid4()),
+            versions=[model]
+        )
         mock_address = AssetSpec.gen_url(VERSION_URL.format(asset_id, version_id))
 
-        m.put(mock_address, json=model.model_dump())
+        m.put(mock_address, json=response.model_dump())
         client = PythonikClient(app_id=app_id, auth_token=auth_token, timeout=3)
 
         client.assets().update_version(


### PR DESCRIPTION
- Fix partial_update_version() and update_version() to use AssetVersionResponse
- Update unit tests to mock correct response model
- Update CHANGELOG.md for version 1.9.2
- Add integration test files to .gitignore