### PR TITLE
chore(git): add macOS-specific patterns to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -164,3 +164,40 @@ pythonik/tests/test_*_integration.py
 
 # Misc.
 IGNORE
+
+# Created by https://www.toptal.com/developers/gitignore/api/macos
+# Edit at https://www.toptal.com/developers/gitignore?templates=macos
+
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### macOS Patch ###
+# iCloud generated files
+*.icloud
+
+# End of https://www.toptal.com/developers/gitignore/api/macos


### PR DESCRIPTION
# Add macOS-specific patterns to gitignore

## Changes
- Added standard macOS-specific patterns from gitignore.io to the `.gitignore` file
- Includes patterns for `.DS_Store`, icon files, thumbnails, and other macOS-generated files
- Prevents accidental commits of macOS-specific system files

## Reason
This change improves cross-platform development experience by ensuring macOS-specific
system files don't get committed to the repository. These files are not needed for the project
and can cause confusion or conflicts for developers on other platforms.

## Testing
- Verified that patterns match standard macOS gitignore templates
- No functional code changes, so no tests were required

## Related Issues
N/A